### PR TITLE
Implement nonce caching (fix #25) and CI/CD pipelines (fix #20)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,39 @@
+name: CI
+
+on:
+  pull_request:
+    branches:
+      - main
+
+concurrency:
+  group: ci-${{ github.head_ref }}
+  cancel-in-progress: true
+
+jobs:
+  ci:
+    name: Lint, Typecheck & Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm turbo lint
+
+      - name: Typecheck
+        run: pnpm turbo check-types
+
+      - name: Test
+        run: pnpm turbo test

--- a/.github/workflows/deploy-preview.yml
+++ b/.github/workflows/deploy-preview.yml
@@ -1,0 +1,86 @@
+name: Deploy Preview
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - reopened
+      - closed
+
+concurrency:
+  group: deploy-preview-${{ github.head_ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+  pull-requests: write
+
+jobs:
+  deploy-api:
+    name: Preview — API
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: W3Dev/vercel-deploy@main
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_API }}
+          package_manager: pnpm
+          working_directory: apps/api
+          alias_prefix: x402-api
+          environment: preview
+          teardown: true
+          auto_clean_deployment: true
+
+  deploy-web:
+    name: Preview — Web
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: W3Dev/vercel-deploy@main
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+          package_manager: pnpm
+          working_directory: apps/web
+          alias_prefix: x402-web
+          environment: preview
+          teardown: true
+          auto_clean_deployment: true
+
+  deploy-dashboard:
+    name: Preview — Dashboard
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: W3Dev/vercel-deploy@main
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_DASHBOARD }}
+          package_manager: pnpm
+          working_directory: apps/dashboard
+          alias_prefix: x402-dashboard
+          environment: preview
+          teardown: true
+          auto_clean_deployment: true

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -1,0 +1,75 @@
+name: Deploy Production
+
+on:
+  push:
+    branches:
+      - main
+
+concurrency:
+  group: deploy-production
+  cancel-in-progress: false  # never cancel an in-flight production deploy
+
+permissions:
+  contents: read
+
+jobs:
+  deploy-api:
+    name: Production — API (api.x402.vet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: W3Dev/vercel-deploy@main
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_API }}
+          package_manager: pnpm
+          working_directory: apps/api
+          # alias_domain used directly as the production alias target
+          alias_domain: api.x402.vet
+          environment: production
+
+  deploy-web:
+    name: Production — Web (x402.vet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: W3Dev/vercel-deploy@main
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_WEB }}
+          package_manager: pnpm
+          working_directory: apps/web
+          alias_domain: x402.vet
+          environment: production
+
+  deploy-dashboard:
+    name: Production — Dashboard (app.x402.vet)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: W3Dev/vercel-deploy@main
+        with:
+          vercel_token: ${{ secrets.VERCEL_TOKEN }}
+          vercel_org_id: ${{ secrets.VERCEL_ORG_ID }}
+          vercel_project_id: ${{ secrets.VERCEL_PROJECT_ID_DASHBOARD }}
+          package_manager: pnpm
+          working_directory: apps/dashboard
+          alias_domain: app.x402.vet
+          environment: production

--- a/apps/api/src/__tests__/unit/nonce-cache.test.ts
+++ b/apps/api/src/__tests__/unit/nonce-cache.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Unit tests for NonceCacheService
+ *
+ * Strategy:
+ *  - Mock the Drizzle `db` module so tests never touch a real database
+ *  - Use vi.setSystemTime() to control the clock for expiry tests
+ */
+
+import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest'
+
+// ---------------------------------------------------------------------------
+// Mock the database module BEFORE importing the service under test
+// ---------------------------------------------------------------------------
+const mockInsert = vi.fn()
+const mockSelect = vi.fn()
+const mockDelete = vi.fn()
+
+vi.mock('../../db/index.js', () => ({
+  db: {
+    insert: () => ({ values: mockInsert }),
+    select: () => ({ from: () => ({ where: () => ({ limit: mockSelect }) }) }),
+    delete: () => ({ where: mockDelete }),
+  },
+}))
+
+// Import AFTER mocking so the service picks up the mock db
+// We import the class indirectly via the module; re-import a fresh instance per test
+// by resetting module cache between describe blocks where needed.
+import { nonceCacheService } from '../../services/NonceCacheService.js'
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+const WALLET = '0xDeAdBeEf000000000000000000000000DeAdBeEf'
+const NONCE = 'abc123'
+const TTL = 300 // 5 minutes
+
+function nowSeconds(): number {
+  return Math.floor(Date.now() / 1000)
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+describe('NonceCacheService', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2025-01-01T00:00:00Z'))
+    // Clear the service's internal map between tests via the exposed helper
+    // (we call cleanup with a far-future time effectively by clearing directly)
+    ;(nonceCacheService as any).cache.clear()
+    mockInsert.mockReset()
+    mockSelect.mockReset()
+    mockDelete.mockReset()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  // -------------------------------------------------------------------------
+  describe('has()', () => {
+    it('returns false when nonce is unknown (no map entry, DB returns empty)', async () => {
+      mockSelect.mockResolvedValue([])
+
+      const result = await nonceCacheService.has(NONCE, WALLET)
+
+      expect(result).toBe(false)
+      expect(mockSelect).toHaveBeenCalledOnce()
+    })
+
+    it('returns true for a nonce found in the DB and warms the map', async () => {
+      const expiresAt = new Date((nowSeconds() + TTL) * 1000)
+      mockSelect.mockResolvedValue([{ expiresAt }])
+
+      const result = await nonceCacheService.has(NONCE, WALLET)
+
+      expect(result).toBe(true)
+      // Map should now be warmed — a second call must NOT hit the DB
+      mockSelect.mockReset()
+      const resultCached = await nonceCacheService.has(NONCE, WALLET)
+      expect(resultCached).toBe(true)
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    it('returns true from the in-memory map without hitting the DB (cache hit)', async () => {
+      // Pre-warm the map by calling add()
+      mockInsert.mockResolvedValue(undefined)
+      await nonceCacheService.add(NONCE, WALLET, TTL)
+
+      mockSelect.mockReset()
+      const result = await nonceCacheService.has(NONCE, WALLET)
+
+      expect(result).toBe(true)
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    it('returns false for an expired map entry and falls through to DB', async () => {
+      // Add nonce with TTL of 10 seconds
+      mockInsert.mockResolvedValue(undefined)
+      await nonceCacheService.add(NONCE, WALLET, 10)
+
+      // Advance time past expiry
+      vi.advanceTimersByTime(15_000)
+
+      // DB also says gone
+      mockSelect.mockResolvedValue([])
+
+      const result = await nonceCacheService.has(NONCE, WALLET)
+
+      expect(result).toBe(false)
+      expect(mockSelect).toHaveBeenCalledOnce()
+      // Map entry should have been evicted
+      expect((nonceCacheService as any).cache.size).toBe(0)
+    })
+
+    it('returns false when DB entry is expired even though row exists', async () => {
+      const expiresAt = new Date((nowSeconds() - 60) * 1000) // 1 min in the past
+      mockSelect.mockResolvedValue([{ expiresAt }])
+
+      const result = await nonceCacheService.has(NONCE, WALLET)
+
+      expect(result).toBe(false)
+      // Should NOT warm the map with an expired entry
+      expect((nonceCacheService as any).cache.size).toBe(0)
+    })
+
+    it('is case-insensitive for wallet address', async () => {
+      mockInsert.mockResolvedValue(undefined)
+      await nonceCacheService.add(NONCE, WALLET.toUpperCase(), TTL)
+
+      const result = await nonceCacheService.has(NONCE, WALLET.toLowerCase())
+      expect(result).toBe(true)
+      expect(mockSelect).not.toHaveBeenCalled()
+    })
+
+    it('throws when the DB is unreachable (fail-closed)', async () => {
+      mockSelect.mockRejectedValue(new Error('Connection refused'))
+
+      await expect(nonceCacheService.has(NONCE, WALLET)).rejects.toThrow(
+        'Nonce check failed'
+      )
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('add()', () => {
+    it('writes to DB and warms the in-memory map', async () => {
+      mockInsert.mockResolvedValue(undefined)
+
+      await nonceCacheService.add(NONCE, WALLET, TTL)
+
+      expect(mockInsert).toHaveBeenCalledOnce()
+      expect((nonceCacheService as any).cache.size).toBe(1)
+    })
+
+    it('throws on DB unique constraint violation (replay attack)', async () => {
+      mockInsert.mockRejectedValue(new Error('unique constraint violated'))
+
+      await expect(nonceCacheService.add(NONCE, WALLET, TTL)).rejects.toThrow(
+        'Nonce has already been used'
+      )
+      // Map must NOT be polluted on failure
+      expect((nonceCacheService as any).cache.size).toBe(0)
+    })
+
+    it('throws on generic DB error', async () => {
+      mockInsert.mockRejectedValue(new Error('timeout'))
+
+      await expect(nonceCacheService.add(NONCE, WALLET, TTL)).rejects.toThrow(
+        'Failed to cache nonce'
+      )
+    })
+
+    it('uses at least 1 second TTL even when validUntil is in the past', async () => {
+      mockInsert.mockResolvedValue(undefined)
+      // ttlSeconds = -60 (already expired) → should still call add with max(−60, 1) = 1
+      await nonceCacheService.add(NONCE, WALLET, 1)
+
+      expect(mockInsert).toHaveBeenCalledOnce()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('cleanup()', () => {
+    it('removes expired entries from the in-memory map', async () => {
+      mockInsert.mockResolvedValue(undefined)
+
+      await nonceCacheService.add('nonce-1', WALLET, 10)
+      await nonceCacheService.add('nonce-2', WALLET, 600)
+
+      expect((nonceCacheService as any).cache.size).toBe(2)
+
+      // Advance past nonce-1's expiry
+      vi.advanceTimersByTime(15_000)
+
+      nonceCacheService.cleanup()
+
+      expect((nonceCacheService as any).cache.size).toBe(1)
+    })
+
+    it('leaves valid entries untouched', async () => {
+      mockInsert.mockResolvedValue(undefined)
+      await nonceCacheService.add(NONCE, WALLET, TTL)
+
+      nonceCacheService.cleanup()
+
+      expect((nonceCacheService as any).cache.size).toBe(1)
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  describe('purgeExpiredFromDb()', () => {
+    it('calls db.delete with an expires_at condition', async () => {
+      mockDelete.mockResolvedValue(undefined)
+
+      await nonceCacheService.purgeExpiredFromDb()
+
+      expect(mockDelete).toHaveBeenCalledOnce()
+    })
+  })
+})

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -8,6 +8,7 @@ import feeDelegationRoutes from './routes/feeDelegation.js'
 import transactionsRoutes from './routes/transactions.js'
 import analyticsRoutes from './routes/analytics.js'
 import apiKeyRoutes from './routes/apiKeys.js'
+import { nonceCacheService } from './services/NonceCacheService.js'
 
 const app = new Hono()
 
@@ -72,6 +73,23 @@ app.route('/api/keys', apiKeyRoutes)
 
 // Error handling
 app.onError(errorHandler)
+
+// ---------------------------------------------------------------------------
+// Periodic maintenance: clean up expired nonces every 5 minutes.
+// This keeps both the in-process Map and the Postgres table lean.
+// Note: In a serverless (Vercel) environment this interval only runs while
+// the function instance is warm, which is acceptable — correctness is always
+// guaranteed by the DB unique constraint and TTL-aware lookups.
+// ---------------------------------------------------------------------------
+const NONCE_CLEANUP_INTERVAL_MS = 5 * 60 * 1000 // 5 minutes
+setInterval(async () => {
+  try {
+    nonceCacheService.cleanup()
+    await nonceCacheService.purgeExpiredFromDb()
+  } catch (err) {
+    console.error('[nonce-cleanup] Failed to purge expired nonces:', err)
+  }
+}, NONCE_CLEANUP_INTERVAL_MS)
 
 export type AppType = typeof app
 

--- a/apps/api/src/services/NonceCacheService.ts
+++ b/apps/api/src/services/NonceCacheService.ts
@@ -1,0 +1,142 @@
+/**
+ * NonceCacheService
+ *
+ * Two-layer nonce cache for replay attack prevention:
+ *   Layer 1 — In-process Map (zero DB cost for hot lookups)
+ *   Layer 2 — Postgres (authoritative, race-condition safe via unique constraint)
+ *
+ * The in-memory map is a performance optimisation only. Correctness is always
+ * guaranteed by the DB unique constraint even when multiple Vercel function
+ * instances are running concurrently.
+ */
+
+import { db } from '../db/index.js'
+import { nonces } from '../db/schema.js'
+import { and, eq, lt } from 'drizzle-orm'
+
+export interface NonceCache {
+  has(nonce: string, walletAddress: string): Promise<boolean>
+  add(nonce: string, walletAddress: string, ttlSeconds: number): Promise<void>
+  cleanup(): void
+}
+
+// Map key → expiry unix timestamp (seconds)
+type CacheKey = string // `${walletAddress.toLowerCase()}:${nonce}`
+
+function makeKey(walletAddress: string, nonce: string): CacheKey {
+  return `${walletAddress.toLowerCase()}:${nonce}`
+}
+
+class NonceCacheService implements NonceCache {
+  private readonly cache = new Map<CacheKey, number>()
+
+  /**
+   * Check whether a nonce has already been used.
+   *
+   * Lookup order:
+   *  1. In-memory map  — return true/false immediately if entry is present and fresh
+   *  2. Postgres       — on cache miss, query the DB and warm the map on hit
+   */
+  async has(nonce: string, walletAddress: string): Promise<boolean> {
+    const key = makeKey(walletAddress, nonce)
+    const nowSeconds = Math.floor(Date.now() / 1000)
+
+    // Layer 1: in-memory map
+    const cachedExpiry = this.cache.get(key)
+    if (cachedExpiry !== undefined) {
+      if (cachedExpiry > nowSeconds) {
+        return true
+      }
+      // Expired — evict and fall through to DB
+      this.cache.delete(key)
+    }
+
+    // Layer 2: Postgres
+    try {
+      const rows = await db
+        .select({ expiresAt: nonces.expiresAt })
+        .from(nonces)
+        .where(
+          and(
+            eq(nonces.walletAddress, walletAddress.toLowerCase()),
+            eq(nonces.nonce, nonce)
+          )
+        )
+        .limit(1)
+
+      if (rows.length === 0) return false
+
+      // Warm the in-memory cache with the expiry from DB
+      const expirySeconds = Math.floor(rows[0].expiresAt.getTime() / 1000)
+      if (expirySeconds > nowSeconds) {
+        this.cache.set(key, expirySeconds)
+        return true
+      }
+
+      // Row exists but has expired — treat as unused
+      return false
+    } catch (error) {
+      // Fail closed: if the DB is unreachable we must reject to prevent replay attacks
+      throw new Error(
+        `Nonce check failed: ${error instanceof Error ? error.message : 'Unknown error'}`
+      )
+    }
+  }
+
+  /**
+   * Record a nonce as used.
+   *
+   * Writes to Postgres first (atomic, unique constraint prevents duplicates), then
+   * warms the in-memory map. Throws if the nonce is already present (replay attack
+   * or concurrent request race condition).
+   */
+  async add(nonce: string, walletAddress: string, ttlSeconds: number): Promise<void> {
+    const key = makeKey(walletAddress, nonce)
+    const expiresAt = new Date((Math.floor(Date.now() / 1000) + ttlSeconds) * 1000)
+
+    try {
+      await db.insert(nonces).values({
+        walletAddress: walletAddress.toLowerCase(),
+        nonce,
+        expiresAt,
+      })
+    } catch (error) {
+      const msg = error instanceof Error ? error.message : ''
+      if (msg.includes('unique') || msg.includes('duplicate')) {
+        throw new Error('Nonce has already been used (replay attack or concurrent request detected)')
+      }
+      throw new Error(`Failed to cache nonce: ${msg || 'Unknown error'}`)
+    }
+
+    // Warm the map only after a successful DB write
+    this.cache.set(key, Math.floor(expiresAt.getTime() / 1000))
+  }
+
+  /**
+   * Prune expired entries from the in-memory map.
+   * Call this periodically (e.g. every 5 minutes) to prevent unbounded map growth.
+   */
+  cleanup(): void {
+    const nowSeconds = Math.floor(Date.now() / 1000)
+    for (const [key, expiry] of this.cache.entries()) {
+      if (expiry <= nowSeconds) {
+        this.cache.delete(key)
+      }
+    }
+  }
+
+  /**
+   * Delete all expired nonce rows from Postgres.
+   * Intended to be called alongside cleanup() in the periodic maintenance job.
+   */
+  async purgeExpiredFromDb(): Promise<void> {
+    await db.delete(nonces).where(lt(nonces.expiresAt, new Date()))
+  }
+
+  /** Exposed for testing only */
+  get _cacheSize(): number {
+    return this.cache.size
+  }
+}
+
+export const nonceCacheService = new NonceCacheService()

--- a/apps/api/src/services/PaymentVerificationService.ts
+++ b/apps/api/src/services/PaymentVerificationService.ts
@@ -11,9 +11,7 @@
 
 import { Secp256k1, Address, Keccak256, Hex } from '@vechain/sdk-core';
 import type { PaymentPayload, PaymentOption } from '../types/x402.js';
-import { db } from '../db/index.js';
-import { nonces } from '../db/schema.js';
-import { eq, and } from 'drizzle-orm';
+import { nonceCacheService } from './NonceCacheService.js';
 import { VECHAIN_NETWORKS, VECHAIN_TOKENS, SUPPORTED_NETWORKS, TOKEN_REGISTRY } from '../config/vechain.js';
 
 /**
@@ -103,52 +101,21 @@ export function validateTokenAddress(asset: string): boolean {
 
 /**
  * Check if a nonce has been used
- * @param walletAddress Wallet address
- * @param nonce Nonce value
- * @returns true if nonce has been used, false otherwise
+ * Delegates to NonceCacheService (in-memory map → Postgres).
  */
 export async function isNonceUsed(walletAddress: string, nonce: string): Promise<boolean> {
-  try {
-    const result = await db
-      .select()
-      .from(nonces)
-      .where(
-        and(
-          eq(nonces.walletAddress, walletAddress.toLowerCase()),
-          eq(nonces.nonce, nonce)
-        )
-      )
-      .limit(1);
-    
-    return result.length > 0;
-  } catch (error) {
-    // If database is not available or query fails, reject for safety
-    throw new Error(`Nonce check failed: ${error instanceof Error ? error.message : 'Unknown error'}`);
-  }
+  return nonceCacheService.has(nonce, walletAddress)
 }
 
 /**
  * Cache a used nonce to prevent replay attacks
- * @param walletAddress Wallet address
- * @param nonce Nonce value
- * @param validUntil Expiration timestamp
- * @throws Error if nonce already exists (race condition detected) or database error
+ * Delegates to NonceCacheService (Postgres write → warms in-memory map).
+ * @throws if nonce already exists (race condition / replay attack)
  */
 export async function cacheNonce(walletAddress: string, nonce: string, validUntil: number): Promise<void> {
-  try {
-    await db.insert(nonces).values({
-      walletAddress: walletAddress.toLowerCase(),
-      nonce,
-      expiresAt: new Date(validUntil * 1000), // Convert Unix timestamp to Date
-    });
-  } catch (error) {
-    // Check if this is a unique constraint violation (race condition)
-    const errorMessage = error instanceof Error ? error.message : '';
-    if (errorMessage.includes('unique') || errorMessage.includes('duplicate')) {
-      throw new Error('Nonce has already been used (detected concurrent request)');
-    }
-    throw new Error(`Failed to cache nonce: ${errorMessage || 'Unknown error'}`);
-  }
+  const ttlSeconds = validUntil - Math.floor(Date.now() / 1000)
+  // Ensure TTL is at least 1 second to avoid storing already-expired nonces
+  await nonceCacheService.add(nonce, walletAddress, Math.max(ttlSeconds, 1))
 }
 
 /**

--- a/apps/api/vercel.json
+++ b/apps/api/vercel.json
@@ -1,0 +1,16 @@
+{
+  "version": 2,
+  "buildCommand": "pnpm db:migrate && pnpm build",
+  "builds": [
+    {
+      "src": "src/index.ts",
+      "use": "@vercel/node"
+    }
+  ],
+  "routes": [
+    {
+      "src": "/(.*)",
+      "dest": "src/index.ts"
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

- **Issue #25** — Nonce caching for replay attack prevention (DB-backed KV, no Redis)
- **Issue #20** — CI/CD and deployment pipelines (GitHub Actions + Vercel)

## Issue #25 — Nonce Caching

### What changed
- **`NonceCacheService.ts`** (new) — Implements the `NonceCache` interface with a two-layer strategy:
  - **Layer 1:** In-process `Map` for zero-cost hot lookups
  - **Layer 2:** Postgres as authoritative store; unique constraint guarantees correctness under concurrent requests
  - `has()` checks map first, falls through to DB on miss and warms the map
  - `add()` writes to DB atomically first, then warms map — throws on unique constraint violation (replay attack)
  - `cleanup()` prunes expired in-memory entries; `purgeExpiredFromDb()` deletes expired DB rows
- **`PaymentVerificationService.ts`** — `isNonceUsed` and `cacheNonce` now delegate to `NonceCacheService`; direct `db`/`nonces` imports removed
- **`index.ts`** — Periodic maintenance job (`setInterval`, every 5 min) calls `cleanup()` + `purgeExpiredFromDb()`
- **`nonce-cache.test.ts`** (new) — 14 unit tests covering all paths: cache hit, DB miss, expiry, replay detection, fail-closed DB error

> **Note:** The in-memory map is a per-process performance optimisation only. Correctness under multi-instance (Vercel) deployments is always guaranteed by the DB unique constraint.

## Issue #20 — CI/CD Pipelines

### What changed
- **`apps/api/vercel.json`** (new) — Configures Hono as a Vercel Node.js serverless function. `buildCommand` runs `pnpm db:migrate && pnpm build` so migrations execute inside Vercel's build environment where `DATABASE_URL` is already set (Option B — no DB credentials in GitHub secrets)
- **`.github/workflows/ci.yml`** — Runs `turbo lint`, `turbo check-types`, `turbo test` on every PR to `main`
- **`.github/workflows/deploy-preview.yml`** — Three parallel preview deployments (api/web/dashboard) via `W3Dev/vercel-deploy@main` on PR open/update; teardown with alias + deployment cleanup on PR close
- **`.github/workflows/deploy-production.yml`** — Three parallel production deployments to `api.x402.vet` / `x402.vet` / `app.x402.vet` on push to `main`

### Required GitHub Secrets
Add these in **Settings → Secrets → Actions** before merging:
| Secret | Description |
|--------|-------------|
| `VERCEL_TOKEN` | Vercel personal access token |
| `VERCEL_ORG_ID` | Vercel team/org ID (`team_xxxxx`) |
| `VERCEL_PROJECT_ID_API` | Vercel project ID for `apps/api` |
| `VERCEL_PROJECT_ID_WEB` | Vercel project ID for `apps/web` |
| `VERCEL_PROJECT_ID_DASHBOARD` | Vercel project ID for `apps/dashboard` |

Closes #25
Closes #20